### PR TITLE
Initial version of the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM continuumio/miniconda3
+MAINTAINER Susanna Kiwala <ssiebert@wustl.edu>
+
+LABEL \
+    description="Image for pVACtools"
+
+#pVACtools
+RUN pip install -e git+git://github.com/griffithlab/pVACtools@master#egg=pvacseq


### PR DESCRIPTION
This version installs pVACtools from the repo directly, since we don't have a package yet. Once we have a versioned release, I will make another PR. 

There is no entrypoint in this Dockerfile, since the pVACtools package installs multiple entrypoints (`pvacseq`, `pvacfuse`, and `pvacvector`). The CWLs for each individual tool will point to this container.