### PR TITLE
Upgrade to version 1.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,13 @@ MAINTAINER Susanna Kiwala <ssiebert@wustl.edu>
 
 LABEL \
     description="Image for pVACtools" \
-    version="1.4.5_mhci_2.19.2_mhcii_2.17.6"
+    version="1.5.0_mhci_2.19.2_mhcii_2.17.6"
 
 RUN apt-get update && apt-get install -y \
     tcsh \
+    gcc \
+    build-essential \
+    zlib1g-dev \
     gawk
 
 RUN conda create -n pvactools_py27 python=2.7 -y
@@ -44,10 +47,12 @@ RUN bash -l -c "conda activate pvactools_py27 && /opt/conda/envs/pvactools_py27/
 WORKDIR /opt/iedb
 RUN rm IEDB_MHC_II-2.17.6.tar.gz
 
-#pVACtools 1.4.5
+#pVACtools 1.5.0
 RUN mkdir /opt/mhcflurry_data
 ENV MHCFLURRY_DOWNLOADS_CURRENT_RELEASE=1.2.0
 ENV MHCFLURRY_DATA_DIR=/opt/mhcflurry_data
-RUN pip install pvactools==1.4.5
+RUN pip install Cython
+RUN pip install pysam==0.9.0
+RUN pip install pvactools==1.5.0
 RUN pip install mhcnuggets==2.2
 RUN mhcflurry-downloads fetch


### PR DESCRIPTION
pvactools now requires vaxrank which requires pysam which requires whole host of dependencies.